### PR TITLE
Update emp-m2pc to latest version

### DIFF
--- a/lib/EMP/emp-m2pc/CMakeLists.txt
+++ b/lib/EMP/emp-m2pc/CMakeLists.txt
@@ -8,7 +8,7 @@ set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} cmake/)
 
 FIND_PACKAGE(emp-ot)
-INCLUDE_DIRECTORIES(/usr/local/include/emp-tool /usr/local/include/emp-ot ${EMP-OT_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(${EMP-OT_INCLUDE_DIRS})
 
 set (CMAKE_C_FLAGS "-pthread -Wall -march=native -O3 -maes")
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pg -ggdb")

--- a/lib/EMP/emp-m2pc/CMakeLists.txt
+++ b/lib/EMP/emp-m2pc/CMakeLists.txt
@@ -1,5 +1,9 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.4)
 project (emp-m2pc)
+
+# if(POLICY CMP0042)
+#   cmake_policy(SET CMP0042 NEW) # necessary to use rpath on macOS
+# endif()
 
 include_directories(${CMAKE_SOURCE_DIR})
 
@@ -16,17 +20,17 @@ set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++0x")
 
 macro (add_test _name)
 	add_executable("test_${_name}" "test/${_name}.cpp" ${basics})
-	target_link_libraries("test_${_name}"  relic  ${OPENSSL_LIBRARIES} gmp ${EMP-TOOL_LIBRARIES})
+	target_link_libraries("test_${_name}" ${EMP-TOOL_LIBRARIES})
 endmacro()
 
 macro (add_bench _name)
 	add_executable("bench_${_name}" "bench/${_name}.cpp" ${basics})
-	target_link_libraries("bench_${_name}"  relic  ${OPENSSL_LIBRARIES} gmp ${EMP-TOOL_LIBRARIES})
+	target_link_libraries("bench_${_name}" ${EMP-TOOL_LIBRARIES})
 endmacro()
 
 macro (add_example _name)
 	add_executable("example_${_name}" "example/${_name}.cpp" ${basics})
-	target_link_libraries("example_${_name}"  relic  ${OPENSSL_LIBRARIES} gmp ${EMP-TOOL_LIBRARIES})
+	target_link_libraries("example_${_name}" ${EMP-TOOL_LIBRARIES})
 endmacro()
 
 add_test (mal)

--- a/lib/EMP/emp-m2pc/bench/bench_mal2pc.h
+++ b/lib/EMP/emp-m2pc/bench/bench_mal2pc.h
@@ -19,7 +19,7 @@ double bench_mal2pc_all_online(void * f, uint64_t len1, uint64_t len2, uint64_t 
 	for(uint64_t k = 0; k < TIME; ++k) {
 		io->sync();
 		double t1 = timeStamp();
-		Malicious2PC <rt> mal(io, party, len1, len2, len3);
+		Malicious2PC <NetIO, rt> mal(io, party, len1, len2, len3);
 		bool res = false;
 		if(party == ALICE) {
 			mal.alice_run(f, in1);
@@ -52,7 +52,7 @@ void bench_mal2pc_with_offline(double t[3], void * f, uint64_t len1, uint64_t le
 		bool res2 = false;
 		io->sync();
 		double t1 = timeStamp();
-		Malicious2PC<RTCktOpt::off> mal(io, party, len1, len2, len3);
+		Malicious2PC<NetIO, RTCktOpt::off> mal(io, party, len1, len2, len3);
 		if(party == ALICE) {
 			mal.alice_offline(f);
 			t[0] += (timeStamp() - t1);

--- a/lib/EMP/emp-m2pc/bench/bench_mal2pc.h
+++ b/lib/EMP/emp-m2pc/bench/bench_mal2pc.h
@@ -3,6 +3,8 @@
 #include <string>
 using namespace std;
 
+#define SERVER_IP  "127.0.0.1"
+
 template<RTCktOpt rt = off>
 double bench_mal2pc_all_online(void * f, uint64_t len1, uint64_t len2, uint64_t len3, NetIO * io, uint64_t TIME, uint64_t party) {
 	double t = 0;

--- a/lib/EMP/emp-m2pc/bench/mal_decompose.cpp
+++ b/lib/EMP/emp-m2pc/bench/mal_decompose.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
 
 	double tt[] = {0,0,0,0,0,0};
 	for (int k = 0; k < num_runs; ++k) {
-		Malicious2PC<> mal(io, party, l1,l2,l3);
+		Malicious2PC<NetIO> mal(io, party, l1,l2,l3);
 		double t[6];
 		t[0]=wallClock();
 		if(party == ALICE) {

--- a/lib/EMP/emp-m2pc/bench/mal_decompose.cpp
+++ b/lib/EMP/emp-m2pc/bench/mal_decompose.cpp
@@ -1,5 +1,8 @@
 #include <emp-tool>
 #include "malicious/malicious.h"
+
+#define SERVER_IP  "127.0.0.1"
+
 #define AES
 #ifdef AES
 static char file[] = "circuits/files/AES-non-expanded.txt";

--- a/lib/EMP/emp-m2pc/bench/ot_xor_tree.cpp
+++ b/lib/EMP/emp-m2pc/bench/ot_xor_tree.cpp
@@ -3,10 +3,10 @@
 #include "malicious/xor_tree_naive.h"
 #include <iostream>
 using namespace std;
-template<typename T>
-double test_ot(NetIO * io, int party, int length, T* ot = nullptr, int TIME = 10) {
+template<typename IO, template<typename> typename T>
+double test_ot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	if(ot == nullptr) 
-		ot = new T(io);
+		ot = new T<IO>(io);
 	block *b0 = new block[length], *b1 = new block[length], *r = new block[length];
 	PRG prg(fix_key);
 	prg.random_block(b0, length);
@@ -39,8 +39,8 @@ int main2(int argc, char** argv) {
 	parse_party_and_port(argv, &party, &port);
 	NetIO * io = new NetIO(party==ALICE ? nullptr:SERVER_IP, port);
 	XorTree<40, 192> tree(65535, 40);
-	MOTExtension * ot = new MOTExtension(io);
-	double t2 = test_ot<MOTExtension>(io, party, tree.output_size(), ot);
+	MOTExtension<NetIO> * ot = new MOTExtension<NetIO>(io);
+	double t2 = test_ot<NetIO, MOTExtension>(io, party, tree.output_size(), ot);
 	block* blocks = new block[tree.input_size()];
 	block* blocks2 = new block[tree.output_size()];
 	double t1 = timeStamp();
@@ -72,9 +72,9 @@ int main(int argc, char** argv) {
 
 	NetIO * io = new NetIO(party==ALICE ? nullptr:SERVER_IP, port);
 	for(int i = 0; i<4; ++i) {
-		MOTExtension * ot = new MOTExtension(io, 40);
+		MOTExtension<NetIO> * ot = new MOTExtension<NetIO>(io, 40);
 		io->set_nodelay();
-		double t3 = test_ot<MOTExtension>(io, party, 2*n[i], ot);
+		double t3 = test_ot<NetIO, MOTExtension>(io, party, 2*n[i], ot);
 		cout << n[i]<<"\t"<<t3<<endl;
 	}
 	delete io;

--- a/lib/EMP/emp-m2pc/bench/ot_xor_tree.cpp
+++ b/lib/EMP/emp-m2pc/bench/ot_xor_tree.cpp
@@ -3,6 +3,9 @@
 #include "malicious/xor_tree_naive.h"
 #include <iostream>
 using namespace std;
+
+#define SERVER_IP  "127.0.0.1"
+
 template<typename IO, template<typename> typename T>
 double test_ot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	if(ot == nullptr) 

--- a/lib/EMP/emp-m2pc/malicious/malicious.h
+++ b/lib/EMP/emp-m2pc/malicious/malicious.h
@@ -1,20 +1,20 @@
 #ifndef MALICIOUS_2PC_H__
 #define MALICIOUS_2PC_H__
-#include </usr/local/include/emp-tool/emp-tool>
-#include </usr/local/include/emp-ot/emp-ot>
+#include <emp-tool>
+#include <emp-ot>
 
-template<RTCktOpt rt = RTCktOpt::off>
+template<typename IO, RTCktOpt rt = RTCktOpt::off>
 class Malicious2PC { public:
 	string GC_FILE = "GC_FILE";
-	NetIO * io;
+	IO * io;
 	FileIO * fio;
 	MemIO * mio;
 	int party;
 	int n1, n2, n3;
 	PRG prg, *prgs;
 	PRP prp;
-	MOTExtension * ot;
-	MOTExtension * cot;
+	MOTExtension<IO> * ot;
+	MOTExtension<IO> * cot;
 	Commitment commitment;
 	const int ssp = 40;
 	XorTree<> * xortree;
@@ -40,7 +40,7 @@ class Malicious2PC { public:
 	eb_t *C, *D, g1, h1;
 	bn_t bn_r;
 	eb_t g1Tbl[RELIC_EB_TABLE_MAX];
-	Malicious2PC(NetIO * io, int party, int n1, int _n2, int n3) {
+	Malicious2PC(IO * io, int party, int n1, int _n2, int n3) {
 		initialize_relic();
 		this->n1 = n1;
 		this->n3 = n3;
@@ -53,8 +53,8 @@ class Malicious2PC { public:
 		seedB = new block*[2];
 		seedB[0] = new block[n2]; 
 		seedB[1] = new block[n2];
-		ot = new MOTExtension(io);
-		cot = new MOTExtension(io, true);
+		ot = new MOTExtension<IO>(io);
+		cot = new MOTExtension<IO>(io, true);
 		prgs = new PRG[ssp];
 		A = new block[ssp*n1];
 		R = new block[n1*ssp];
@@ -296,7 +296,7 @@ class Malicious2PC { public:
 		for(int j = 0; j < ssp; ++j) {
 			for(int i = 0; i < n2; ++i)
 				B_loc[i] = B[i*ssp+j];
-			HalfGateGen<NetIO, rt> gc(io);
+			HalfGateGen<IO, rt> gc(io);
 			gc.set_delta(gc_delta[j]);
 			local_gc = &gc;
 			xortree->circuit(Bp, B_loc);
@@ -354,7 +354,7 @@ class Malicious2PC { public:
 				io->recv_data(T_dgst[j], 20);
 			}
 			else {
-				HalfGateEva<NetIO, rt> gc(io);
+				HalfGateEva<IO, rt> gc(io);
 				gc.set_file_io(fio);
 				local_gc = &gc;
 
@@ -644,7 +644,7 @@ class Malicious2PC { public:
 		for(int j = 0; j < ssp; ++j) {
 			for(int i = 0; i < n2; ++i)
 				B_loc[i] = B[i*ssp+j];
-			HalfGateGen<NetIO, rt> gc(io);
+			HalfGateGen<IO, rt> gc(io);
 			gc.set_delta(gc_delta[j]);
 			local_gc = &gc;
 			xortree->circuit(Bp, B_loc);
@@ -703,7 +703,7 @@ class Malicious2PC { public:
 				io->recv_data(T_dgst[j], 20);
 			}
 			else {
-				HalfGateEva<NetIO,rt> gc(io);
+				HalfGateEva<IO,rt> gc(io);
 				local_gc = &gc;
 				xortree->circuit(Bp, B_loc);
 				run_function(f, Z, &A[j*n1], Bp);

--- a/lib/EMP/emp-m2pc/test/mal.cpp
+++ b/lib/EMP/emp-m2pc/test/mal.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
 	for(int i = 0; i < l1; ++i)
 		in[i] = true;//(i%2 == 0);
 	void * f = (void*)(compute);
-	Malicious2PC<RTCktOpt::off> mal(io, party, l1,l2,l3);
+	Malicious2PC<NetIO, RTCktOpt::off> mal(io, party, l1,l2,l3);
 	double t1 = wallClock();
 	if(party == ALICE) {
 			mal.alice_run(f, in);


### PR DESCRIPTION
Necessary change to support mac OS (old versions of emp-m2pc do not compile on mac OS).

This pull request might depend on #20.