### PR TITLE
Fix a workaround for macOS in MaliciousOTExtension

### DIFF
--- a/lib/MaliciousOTExtension/Makefile
+++ b/lib/MaliciousOTExtension/Makefile
@@ -24,7 +24,10 @@ LIBMIRACL = $(prefix)/lib/libmiracl.a
 
 LIBRARIES=$(INCLUDE_ARCHIVES_START) -lpthread -lssl $(LIBMIRACL) -lcrypto 
 ifeq ($(uname_S),Darwin) # bugfix in mac os x
+ifneq ("$(wildcard /usr/local/Cellar/gcc49/4.9.1/lib/gcc/x86_64-apple-darwin13.3.0/4.9.1/libstdc++.a)","")
+	# if the file exists
 	LIBRARIES += /usr/local/Cellar/gcc49/4.9.1/lib/gcc/x86_64-apple-darwin13.3.0/4.9.1/libstdc++.a
+endif
 endif
 LIBRARIES += $(INCLUDE_ARCHIVES_END) #-lgmp -lgmpxx
 


### PR DESCRIPTION
An old workaround for macOS prevents the compilation of MaliciousOTExtension with clang, because the file /usr/local/Cellar/gcc49/4.9.1/lib/gcc/x86_64-apple-darwin13.3.0/4.9.1/libstdc++.a might not exist. This fix is a workaround for this issue: if the file does not exist, it is ignored.
There might still be an issue when the file exists but clang is used, but hopefully this won't happen in usual settings.