### PR TITLE
Fix a bug with `toString` in `Dlog.hpp`

### DIFF
--- a/include/primitives/Dlog.hpp
+++ b/include/primitives/Dlog.hpp
@@ -640,9 +640,9 @@ public:
 	int getK1() override { return k; }
 
 	string toString() override {
-		string s = "ECF2mTrinomialBasis [k=" + k;
-		s += ", m=" + m;
-		s+= ", a=" + (string)a + ", b="	+ (string) b + ", xG=" + (string) xG + ", yG=" + (string) yG + ", h=" + (string) h + ", q=" + (string) q + "]";
+		string s = string("ECF2mTrinomialBasis [k=") + to_string(k);
+		s += string(", m=") + to_string(m);
+		s += ", a=" + (string)a + ", b="	+ (string) b + ", xG=" + (string) xG + ", yG=" + (string) yG + ", h=" + (string) h + ", q=" + (string) q + "]";
 		return s;
 	}
 };


### PR DESCRIPTION
Fix a bug with `toString` in `Dlog.hpp`.

Bug found thanks to the following warning from clang:

```
Simple/../../include/primitives/Dlog.hpp:643:40: warning: adding 'int' to a string does not append
      to the string [-Wstring-plus-int]
                string s = "ECF2mTrinomialBasis [k=" + k;
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
Simple/../../include/primitives/Dlog.hpp:643:40: note: use array indexing to silence this warning
                string s = "ECF2mTrinomialBasis [k=" + k;
                                                     ^
                           &                         [  ]
Simple/../../include/primitives/Dlog.hpp:644:15: warning: adding 'int' to a string does not append
      to the string [-Wstring-plus-int]
                s += ", m=" + m;
                     ~~~~~~~^~~
Simple/../../include/primitives/Dlog.hpp:644:15: note: use array indexing to silence this warning
                s += ", m=" + m;
                            ^
                     &      [  ]
```

The copyright of the file appears to have changed because it used LF end-of-line markers instead of CRLF (as the other parts of the file).