### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ protocols/MaliciousYao/OnlineP1_*
 protocols/MaliciousYao/OnlineP2_*
 protocols/GMW/NigelAes9Parties.txt
 protocols/GMW/AesInputs*.txt
+
+# macOS specific
+.DS_Store


### PR DESCRIPTION
The .DS_Store files are created by macOS and should not be committed.