### PR TITLE
Fix bug: added ':' in function toString in class IVCiphertext

### DIFF
--- a/include/cryptoInfra/PlainText.hpp
+++ b/include/cryptoInfra/PlainText.hpp
@@ -375,7 +375,7 @@ public:
 
 	string toString() override {
 		const byte * uc = &(iv[0]);
-		return cipher->toString() + string(reinterpret_cast<char const*>(uc), iv.size());
+		return cipher->toString() + ":" + string(reinterpret_cast<char const*>(uc), iv.size());
 	};
 
 	void initFromString(const string & s) override {


### PR DESCRIPTION
Hi,

I fixed the following error:

In class IVCiphertext (PlainText.hpp), in the function initFromString(), the ciphertext and the IV are fetched from a string which should include a ':' to separate the two. However, in function toString(), the ciphertext and IV are concatenated without a ':' to separate them, so I added that.