### PR TITLE
Added extra function commit with parameter r for randomness

### DIFF
--- a/include/interactive_mid_protocols/CommitmentScheme.hpp
+++ b/include/interactive_mid_protocols/CommitmentScheme.hpp
@@ -351,9 +351,17 @@ public:
 	* channel.write(msg3);
 	*
 	* @param input The value that the committer commits about.
+	* @param r	The randomness used for the commitment on input
 	* @param id Unique value attached to the input to keep track of the commitments in the case
 	* that many commitments are performed one after the other without decommiting them yet.
 	* @return the generated commitment object.
+	*/
+
+	virtual shared_ptr<CmtCCommitmentMsg> generateCommitmentMsg(const shared_ptr<CmtCommitValue> & input, biginteger r, long id) = 0;
+
+	/*
+	* This function returns the previous function with the randomness r randomly generated
+	* @return the generated commitment object
 	*/
 	virtual shared_ptr<CmtCCommitmentMsg> generateCommitmentMsg(const shared_ptr<CmtCommitValue> & input, long id) = 0;
 

--- a/include/interactive_mid_protocols/CommitmentSchemePedersen.hpp
+++ b/include/interactive_mid_protocols/CommitmentSchemePedersen.hpp
@@ -280,9 +280,17 @@ private:
 
 public:
 	/**
-	* Runs the following lines of the commitment scheme: 
-	* "SAMPLE a random value r <- Zq
+	* Runs the following line of the commitment scheme: 
 	* 	COMPUTE  c = g^r * h^x". 
+	* with predetermined randomness r
+	*/
+	shared_ptr<CmtCCommitmentMsg> generateCommitmentMsg(const shared_ptr<CmtCommitValue> & input, biginteger r, long id) override;
+
+
+	/**
+	* Runs the following lines of the commitment scheme:
+	* "SAMPLE a random value r <- Zq
+	* 	COMPUTE  c = g^r * h^x".
 	*/
 	shared_ptr<CmtCCommitmentMsg> generateCommitmentMsg(const shared_ptr<CmtCommitValue> & input, long id) override;
 	


### PR DESCRIPTION
Hello,

I created an extra function commit for the Pedersen commitment scheme in such a way that the user can feed the randomness used for the commitment to the function himself, instead of having the function generate randomness. This can be useful in settings where a user wants to use a previously computed string or a string of a certain length as randomness. As an example, I would refer to the input commitment protocol of the GMW compiler by Goldreich in which two parties first commit on random coins using a secure coin tossing protocol and then use the coins as randomness for commitments on their input values.

Of course, this function could also be implemented for ElGamal, but I would just like to know if you are willing to accept this pull request.

Kind regards,
Ruth